### PR TITLE
Made package bower-aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 .plugin
 .metadata/*
+*.iml

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "bootstrap-ui-datetime-picker",
+  "name": "angular-ui-datetime-picker-popup",
   "version": "0.1.0",
   "homepage": "https://github.com/Gillardo/bootstrap-ui-datetime-picker",
   "authors": [

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,30 @@
+{
+  "name": "bootstrap-ui-datetime-picker",
+  "version": "0.1.0",
+  "homepage": "https://github.com/Gillardo/bootstrap-ui-datetime-picker",
+  "authors": [
+    "Gillardo <Gillardo@your.email.here.com>",
+    "krico <github@cwa.to>"
+  ],
+  "description": "AngularJs directive to use a date and/or time picker as a dropdown from an input",
+  "main": [
+    "dist/datetime-picker.js",
+    "dist/datetime-picker.min.js",
+    "dist/datetime-picker.tpls.js"
+  ],
+  "keywords": [
+    "date-picker",
+    "time-picker",
+    "angular",
+    "bootstrap",
+    "angular-ui"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "bower_components",
     "test",
     "template",
-    "datetime-picker.js",
+    "/datetime-picker.js",
     "gruntfile.js",
     "package.json",
     "tests"

--- a/bower.json
+++ b/bower.json
@@ -3,14 +3,12 @@
   "version": "0.1.0",
   "homepage": "https://github.com/Gillardo/bootstrap-ui-datetime-picker",
   "authors": [
-    "Gillardo <Gillardo@your.email.here.com>",
+    "Gillardo",
     "krico <github@cwa.to>"
   ],
   "description": "AngularJs directive to use a date and/or time picker as a dropdown from an input",
   "main": [
-    "dist/datetime-picker.js",
-    "dist/datetime-picker.min.js",
-    "dist/datetime-picker.tpls.js"
+    "dist/datetime-picker.min.js"
   ],
   "keywords": [
     "date-picker",
@@ -25,6 +23,10 @@
     "node_modules",
     "bower_components",
     "test",
+    "template",
+    "datetime-picker.js",
+    "gruntfile.js",
+    "package.json",
     "tests"
   ]
 }

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Or use bower
 ```
 bower install bootstrap-ui-datetime-picker -S
 ```
+and link with `bower_components/angular-ui-datetime-picker-popup/dist/datetime-picker.min.js`
 
 ## Usage
 You have the following properties available to use with the directive.  All are optional unless stated otherwise
@@ -69,12 +70,8 @@ Object to configure settings for the timepicker (can be found on angularUI site)
 Personally i dont like the look of the angular-ui calendar itself, this is because the buttons are configured to use the btn-default style.  To get round this i have added a class called datetime-picker to the surrounding div element that contains the angular-ui datepicker.  Using this you can change the style of the calendar.  For example, if i add this css code, you will see the difference to the calendar in the images below
 
 ```sh
-.datetime-picker {
-    div > table {
-        .btn-default {
-            border: 0;
-        }
-    }
+.datetime-picker div > table .btn-default {
+    border: 0;
 }
 ```
 ###### BEFORE

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,11 @@ angular.module('app', ['ui.bootstrap', 'ui.bootstrap.datetimepicker']);
 ```
 Download the source from dist/datetime-picker.min.js file and include it in your project.
 
+Or use bower
+```
+bower install bootstrap-ui-datetime-picker -S
+```
+
 ## Usage
 You have the following properties available to use with the directive.  All are optional unless stated otherwise
 * ngModel (required) - Your date object


### PR DESCRIPTION
I was looking for the functionality you implemented and landed on [this stackoverflow question](http://stackoverflow.com/questions/17785680/using-angular-ui-bootstrap-datepicker-and-timepicker-in-a-popup) where I saw your comment.  I read the doc, but I wasn't happy having to "copy the file into...".

So I made it bower-aware!  I don't want to register the package in the bower registry as you are the author, so for now I am using it with

```
bower install git@github.com:krico/bootstrap-ui-datetime-picker
```

But you should probably just [register it](http://bower.io/docs/creating-packages/#register). 

You will need to add semver git tags, 

* I picked MIT license, not sure about it.
* Feel free to remove my name from authors (really, I won't be offended)
* I too the name from package.json "angular-ui-datetime-picker-popup"