### PR TITLE
do not fall back to new Date() if parse fails

### DIFF
--- a/datetime-picker.js
+++ b/datetime-picker.js
@@ -138,7 +138,7 @@
                             ngModel.$setValidity('date', true);
                             return viewValue;
                         } else if (angular.isString(viewValue)) {
-                            var date = dateParser.parse(viewValue, dateFormat) || new Date(viewValue);
+                            var date = dateParser.parse(viewValue, dateFormat);
 
                             if (isNaN(date)) {
                                 ngModel.$setValidity('date', false);


### PR DESCRIPTION
some browsers, notably IE, will produce valid date objects from invalid date strings when using new Date(..). 
this causes some unconsistent validation when manually changing the date string.

for example, with a date format of "dd-MM-yyyy  HH:mm": 
- in IE11 new Date("24-6000-2015  00:00") will return a valid date.
- in chrome & firefox the same returns an invalid date