### PR TITLE
Made the example easier to copy and paste

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ app.controller('MyController', ['$scope', function($scope) {
         e.stopPropagation();
         
         $scope.isOpen = true;
-    }
+    };
 }]);
 ```
 


### PR DESCRIPTION
Made the example easier to copy and paste, since many linters require optional semicolons.