### PR TITLE
Fixed an issue where an array for main was causing a TypeError.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
   ],
   "description": "AngularJs directive to use a date and/or time picker as a dropdown from an input",
   "license": "MIT",
-  "main": [
-    "dist/datetime-picker.js"
-  ],
+  "main": "dist/datetime-picker.js",
   "dependencies": {
     "angular": "^1.3.0",
     "angular-ui-bootstrap": "~0.14.0"


### PR DESCRIPTION
We were getting the following error when installing. This pull requests fixes that problem for us.

```
1154 verbose stack TypeError: Path must be a string. Received [ 'dist/datetime-picker.js' ]
1154 verbose stack     at assertPath (path.js:8:11)
1154 verbose stack     at Object.posix.resolve (path.js:426:5)
1154 verbose stack     at Packer.applyIgnores (/usr/local/lib/node_modules/npm/node_modules/fstream-npm/fstream-npm.js:109:59)
1154 verbose stack     at Packer.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/ignore.js:181:17)
1154 verbose stack     at Array.filter (native)
1154 verbose stack     at Packer.IgnoreReader.filterEntries (/usr/local/lib/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/ignore.js:179:31)
1154 verbose stack     at Packer.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/ignore.js:92:12)
1154 verbose stack     at Packer.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/fstream-npm/node_modules/fstream-ignore/ignore.js:134:5)
1154 verbose stack     at /usr/local/lib/node_modules/npm/node_modules/graceful-fs/graceful-fs.js:76:16
1154 verbose stack     at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:380:3)
```