### PR TITLE
Add support for customising the intial picker and for controlling which picker is opened by default on subsequent opens

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ You have the following properties available to use with the directive.  All are 
 * enableDate (true/false)
 * enableTime (true/false)
 * buttonBar (object)
+* initialPicker ('date'/'time')
+* reOpenDefault (false/'date'/'time') - NOTE: `true` not supported
 * dateDisabled
 * datepickerOptions (object)
 * timepickerOptions (object)
@@ -45,6 +47,10 @@ Whether you would like the user to be able to select a time. Defaults to true
 ##### buttonBar
 To show or hide the button bar, or any of the buttons inside it. Defaults to the uiDatetimePickerConfig.
 Only specify the elements that you want to override, as each button defaults to the uiDatetimePickerConfig setup, if it is not configured on scope of the datetimePicker
+##### initialPicker
+The initial picker to open when the control is first pressed
+##### reOpenDefault
+The picker to set as the picker to open once the control has already been opened at least once. Setting to `false` will default to the date picker if both date and time are enabled, or just the enabled control if only time or date is in use.
 ##### dateDisabled
 From angularUI site -> An optional expression to disable visible options based on passing date and current mode (day|month|year).
 ##### datepickerOptions

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Now datetimePicker options are globally set by default.  If you do not state the
             'datetime-local': 'yyyy-MM-ddTHH:mm:ss.sss',
             'month': 'yyyy-MM'
         },
+        initialPicker: 'date',
+        reOpenDefault: false,
         enableDate: true,
         enableTime: true,
         buttonBar: {

--- a/datetime-picker.js
+++ b/datetime-picker.js
@@ -1,4 +1,7 @@
-﻿angular.module('ui.bootstrap.datetimepicker', ['ui.bootstrap.dateparser', 'ui.bootstrap.position'])
+// https://github.com/Gillardo/bootstrap-ui-datetime-picker
+// Version: 2.2.0
+// Released: 2016-01-28 
+angular.module('ui.bootstrap.datetimepicker', ['ui.bootstrap.dateparser', 'ui.bootstrap.position'])
     .constant('uiDatetimePickerConfig', {
         dateFormat: 'yyyy-MM-dd HH:mm',
         defaultTime: '00:00:00',
@@ -7,6 +10,8 @@
             'datetime-local': 'yyyy-MM-ddTHH:mm:ss.sss',
             'month': 'yyyy-MM'
         },
+        initialPicker: 'date',
+        reOpenDefault: false,
         enableDate: true,
         enableTime: true,
         buttonBar: {
@@ -60,8 +65,19 @@
                 scope.enableDate = angular.isDefined(scope.enableDate) ? scope.enableDate : uiDatetimePickerConfig.enableDate;
                 scope.enableTime = angular.isDefined(scope.enableTime) ? scope.enableTime : uiDatetimePickerConfig.enableTime;
 
+                // determine default picker
+                scope.initialPicker = angular.isDefined(attrs.initialPicker) ? attrs.initialPicker : uiDatetimePickerConfig.initialPicker;
+
+                // determine the picker to open when control is re-opened
+                scope.reOpenDefault = angular.isDefined(attrs.reOpenDefault) ? attrs.reOpenDefault : uiDatetimePickerConfig.reOpenDefault;
+
+                // check if an illegal combination of options exists
+                if (scope.initialPicker == 'date' && !scope.enableDate) {
+                    throw new Error("datetimePicker can't have initialPicker set to date and have enableDate set to false.");
+                }
+
                 // default picker view
-                scope.showPicker = scope.enableDate ? 'date' : 'time';
+                scope.showPicker = !scope.enableDate ? 'time' : scope.initialPicker;
 
                 var isHtml5DateInput = false;
 
@@ -394,7 +410,7 @@
 
                 // if enableDate and enableTime are true, reopen the picker in date mode first
                 if (scope.enableDate && scope.enableTime)
-                    scope.showPicker = 'date';
+                    scope.showPicker = scope.reOpenDefault === false ? 'date' : scope.reOpenDefault;
 
                 // if a on-close-fn has been defined, lets call it
                 // we only call this if closePressed is defined!
@@ -531,6 +547,8 @@
                 isOpen: '=?',
                 enableDate: '=?',
                 enableTime: '=?',
+                initialPicker: '=?',
+                reOpenDefault: '=?',
                 dateDisabled: '&',
                 customClass: '&',
                 whenClosed: '&'
@@ -560,3 +578,16 @@
             templateUrl: 'template/time-picker.html'
         };
     });
+angular.module('ui.bootstrap.datetimepicker').run(['$templateCache', function($templateCache) {
+  'use strict';
+
+  $templateCache.put('template/date-picker.html',
+    "<ul class=\"dropdown-menu dropdown-menu-left datetime-picker-dropdown\" ng-if=\"isOpen && showPicker == 'date'\" ng-style=dropdownStyle style=left:inherit ng-keydown=keydown($event) ng-click=$event.stopPropagation()><li style=\"padding:0 5px 5px 5px\" class=date-picker-menu><div ng-transclude></div></li><li style=padding:5px ng-if=buttonBar.show><span class=\"btn-group pull-left\" style=margin-right:10px ng-if=\"doShow('today') || doShow('clear')\"><button type=button class=\"btn btn-sm btn-info\" ng-if=\"doShow('today')\" ng-click=\"select('today')\" ng-disabled=\"isDisabled('today')\">{{ getText('today') }}</button> <button type=button class=\"btn btn-sm btn-danger\" ng-if=\"doShow('clear')\" ng-click=\"select('clear')\">{{ getText('clear') }}</button></span> <span class=\"btn-group pull-right\" ng-if=\"(doShow('time') && enableTime) || doShow('close')\"><button type=button class=\"btn btn-sm btn-default\" ng-if=\"doShow('time') && enableTime\" ng-click=\"changePicker($event, 'time')\">{{ getText('time')}}</button> <button type=button class=\"btn btn-sm btn-success\" ng-if=\"doShow('close')\" ng-click=close(true)>{{ getText('close') }}</button></span></li></ul>"
+  );
+
+
+  $templateCache.put('template/time-picker.html',
+    "<ul class=\"dropdown-menu dropdown-menu-left datetime-picker-dropdown\" ng-if=\"isOpen && showPicker == 'time'\" ng-style=dropdownStyle style=left:inherit ng-keydown=keydown($event) ng-click=$event.stopPropagation()><li style=\"padding:0 5px 5px 5px\" class=time-picker-menu><div ng-transclude></div></li><li style=padding:5px ng-if=buttonBar.show><span class=\"btn-group pull-left\" style=margin-right:10px ng-if=\"doShow('now') || doShow('clear')\"><button type=button class=\"btn btn-sm btn-info\" ng-if=\"doShow('now')\" ng-click=\"select('now')\" ng-disabled=\"isDisabled('now')\">{{ getText('now') }}</button> <button type=button class=\"btn btn-sm btn-danger\" ng-if=\"doShow('clear')\" ng-click=\"select('clear')\">{{ getText('clear') }}</button></span> <span class=\"btn-group pull-right\" ng-if=\"(doShow('date') && enableDate) || doShow('close')\"><button type=button class=\"btn btn-sm btn-default\" ng-if=\"doShow('date') && enableDate\" ng-click=\"changePicker($event, 'date')\">{{ getText('date')}}</button> <button type=button class=\"btn btn-sm btn-success\" ng-if=\"doShow('close')\" ng-click=close(true)>{{ getText('close') }}</button></span></li></ul>"
+  );
+
+}]);

--- a/datetime-picker.js
+++ b/datetime-picker.js
@@ -66,7 +66,7 @@ angular.module('ui.bootstrap.datetimepicker', ['ui.bootstrap.dateparser', 'ui.bo
                 scope.enableTime = angular.isDefined(scope.enableTime) ? scope.enableTime : uiDatetimePickerConfig.enableTime;
 
                 // determine default picker
-                scope.initialPicker = angular.isDefined(attrs.initialPicker) ? attrs.initialPicker : uiDatetimePickerConfig.initialPicker;
+                scope.initialPicker = angular.isDefined(attrs.initialPicker) ? attrs.initialPicker : (scope.enableDate ? uiDatetimePickerConfig.initialPicker : 'time');
 
                 // determine the picker to open when control is re-opened
                 scope.reOpenDefault = angular.isDefined(attrs.reOpenDefault) ? attrs.reOpenDefault : uiDatetimePickerConfig.reOpenDefault;

--- a/datetime-picker.js
+++ b/datetime-picker.js
@@ -1,6 +1,3 @@
-// https://github.com/Gillardo/bootstrap-ui-datetime-picker
-// Version: 2.2.0
-// Released: 2016-01-28 
 angular.module('ui.bootstrap.datetimepicker', ['ui.bootstrap.dateparser', 'ui.bootstrap.position'])
     .constant('uiDatetimePickerConfig', {
         dateFormat: 'yyyy-MM-dd HH:mm',
@@ -578,16 +575,3 @@ angular.module('ui.bootstrap.datetimepicker', ['ui.bootstrap.dateparser', 'ui.bo
             templateUrl: 'template/time-picker.html'
         };
     });
-angular.module('ui.bootstrap.datetimepicker').run(['$templateCache', function($templateCache) {
-  'use strict';
-
-  $templateCache.put('template/date-picker.html',
-    "<ul class=\"dropdown-menu dropdown-menu-left datetime-picker-dropdown\" ng-if=\"isOpen && showPicker == 'date'\" ng-style=dropdownStyle style=left:inherit ng-keydown=keydown($event) ng-click=$event.stopPropagation()><li style=\"padding:0 5px 5px 5px\" class=date-picker-menu><div ng-transclude></div></li><li style=padding:5px ng-if=buttonBar.show><span class=\"btn-group pull-left\" style=margin-right:10px ng-if=\"doShow('today') || doShow('clear')\"><button type=button class=\"btn btn-sm btn-info\" ng-if=\"doShow('today')\" ng-click=\"select('today')\" ng-disabled=\"isDisabled('today')\">{{ getText('today') }}</button> <button type=button class=\"btn btn-sm btn-danger\" ng-if=\"doShow('clear')\" ng-click=\"select('clear')\">{{ getText('clear') }}</button></span> <span class=\"btn-group pull-right\" ng-if=\"(doShow('time') && enableTime) || doShow('close')\"><button type=button class=\"btn btn-sm btn-default\" ng-if=\"doShow('time') && enableTime\" ng-click=\"changePicker($event, 'time')\">{{ getText('time')}}</button> <button type=button class=\"btn btn-sm btn-success\" ng-if=\"doShow('close')\" ng-click=close(true)>{{ getText('close') }}</button></span></li></ul>"
-  );
-
-
-  $templateCache.put('template/time-picker.html',
-    "<ul class=\"dropdown-menu dropdown-menu-left datetime-picker-dropdown\" ng-if=\"isOpen && showPicker == 'time'\" ng-style=dropdownStyle style=left:inherit ng-keydown=keydown($event) ng-click=$event.stopPropagation()><li style=\"padding:0 5px 5px 5px\" class=time-picker-menu><div ng-transclude></div></li><li style=padding:5px ng-if=buttonBar.show><span class=\"btn-group pull-left\" style=margin-right:10px ng-if=\"doShow('now') || doShow('clear')\"><button type=button class=\"btn btn-sm btn-info\" ng-if=\"doShow('now')\" ng-click=\"select('now')\" ng-disabled=\"isDisabled('now')\">{{ getText('now') }}</button> <button type=button class=\"btn btn-sm btn-danger\" ng-if=\"doShow('clear')\" ng-click=\"select('clear')\">{{ getText('clear') }}</button></span> <span class=\"btn-group pull-right\" ng-if=\"(doShow('date') && enableDate) || doShow('close')\"><button type=button class=\"btn btn-sm btn-default\" ng-if=\"doShow('date') && enableDate\" ng-click=\"changePicker($event, 'date')\">{{ getText('date')}}</button> <button type=button class=\"btn btn-sm btn-success\" ng-if=\"doShow('close')\" ng-click=close(true)>{{ getText('close') }}</button></span></li></ul>"
-  );
-
-}]);

--- a/example/index.html
+++ b/example/index.html
@@ -7,7 +7,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/1.1.0/ui-bootstrap-tpls.js"></script>
     <script src="datetime-picker.js"></script>
-    <script src="script.js"></script>
+    <script src="index.js"></script>
 </head>
 <body style="padding:10px;" class="container-fluid">
 <h1>DateTime Picker Demo</h1>
@@ -263,6 +263,78 @@
             <label class="col-sm-2 control-label">On Close</label>
             <div class="col-sm-10">
                 <p class="form-control-static">{{ ctrl.closedArgs }}</p>
+            </div>
+        </div>
+    </form>
+    <h3>Initial picker</h3>
+    <form class="form-horizontal">
+        <div class="form-group">
+            <label class="col-sm-2 control-label">Date</label>
+            <div class="col-sm-10">
+                <p class="input-group">
+                    <input type="text" class="form-control" datetime-picker="dd/MM/yyyy HH:mm" ng-model="ctrl.dates.date14" is-open="ctrl.open.date14" initial-picker="date"/>
+              <span class="input-group-btn">
+                  <button type="button" class="btn btn-default" ng-click="ctrl.openCalendar($event, 'date14')"><i class="fa fa-clock-o"></i></button>
+              </span>
+                </p>
+            </div>
+        </div>
+        <div class="form-group">
+            <label class="col-sm-2 control-label">Time</label>
+            <div class="col-sm-10">
+                <p class="input-group">
+                    <input type="text" class="form-control" datetime-picker="dd/MM/yyyy HH:mm" ng-model="ctrl.dates.date16" is-open="ctrl.open.date16" initial-picker="time"/>
+              <span class="input-group-btn">
+                  <button type="button" class="btn btn-default" ng-click="ctrl.openCalendar($event, 'date16')"><i class="fa fa-clock-o"></i></button>
+              </span>
+                </p>
+            </div>
+        </div>
+    </form>
+    <h3>Initial picker with re-open default</h3>
+    <form class="form-horizontal">
+        <div class="form-group">
+            <label class="col-sm-6 control-label">Date on initial, date there after</label>
+            <div class="col-sm-6">
+                <p class="input-group">
+                    <input type="text" class="form-control" datetime-picker="dd/MM/yyyy HH:mm" ng-model="ctrl.dates.date17" is-open="ctrl.open.date17" initial-picker="date" re-open-default="date"/>
+              <span class="input-group-btn">
+                  <button type="button" class="btn btn-default" ng-click="ctrl.openCalendar($event, 'date17')"><i class="fa fa-clock-o"></i></button>
+              </span>
+                </p>
+            </div>
+        </div>
+        <div class="form-group">
+            <label class="col-sm-6 control-label">Date on initial, time there after</label>
+            <div class="col-sm-6">
+                <p class="input-group">
+                    <input type="text" class="form-control" datetime-picker="dd/MM/yyyy HH:mm" ng-model="ctrl.dates.date18" is-open="ctrl.open.date18" initial-picker="date" re-open-default="time"/>
+              <span class="input-group-btn">
+                  <button type="button" class="btn btn-default" ng-click="ctrl.openCalendar($event, 'date18')"><i class="fa fa-clock-o"></i></button>
+              </span>
+                </p>
+            </div>
+        </div>
+        <div class="form-group">
+            <label class="col-sm-6 control-label">Time on initial, time there after</label>
+            <div class="col-sm-6">
+                <p class="input-group">
+                    <input type="text" class="form-control" datetime-picker="dd/MM/yyyy HH:mm" ng-model="ctrl.dates.date19" is-open="ctrl.open.date19" initial-picker="time" re-open-default="time"/>
+              <span class="input-group-btn">
+                  <button type="button" class="btn btn-default" ng-click="ctrl.openCalendar($event, 'date19')"><i class="fa fa-clock-o"></i></button>
+              </span>
+                </p>
+            </div>
+        </div>
+        <div class="form-group">
+            <label class="col-sm-6 control-label">Time on initial, date there after</label>
+            <div class="col-sm-6">
+                <p class="input-group">
+                    <input type="text" class="form-control" datetime-picker="dd/MM/yyyy HH:mm" ng-model="ctrl.dates.date15" is-open="ctrl.open.date15" initial-picker="time" re-open-default="date"/>
+              <span class="input-group-btn">
+                  <button type="button" class="btn btn-default" ng-click="ctrl.openCalendar($event, 'date15')"><i class="fa fa-clock-o"></i></button>
+              </span>
+                </p>
             </div>
         </div>
     </form>

--- a/example/index.js
+++ b/example/index.js
@@ -21,6 +21,12 @@ app.controller('MyController', ['$scope', function($scope) {
         date11: new Date('2015-03-01T10:00:00Z'),
         date12: new Date('2015-03-01T10:00:00Z'),
         date13: null,
+        date14: new Date('2016-02-16T10:00:00Z'),
+        date15: new Date('2016-02-16T10:00:00Z'),
+        date16: new Date('2016-02-16T10:00:00Z'),
+        date17: new Date('2016-02-16T10:00:00Z'),
+        date18: new Date('2016-02-16T10:00:00Z'),
+        date19: new Date('2016-02-16T10:00:00Z'),
     };
 
     this.open = {
@@ -36,7 +42,13 @@ app.controller('MyController', ['$scope', function($scope) {
         date10: false,
         date11: false,
         date12: false,
-        date13: false
+        date13: false,
+        date14: false,
+        date15: false,
+        date16: false,
+        date17: false,
+        date18: false,
+        date19: false
     };
 
     // Disable today selection


### PR DESCRIPTION
2 new options:

initialPicker: 'time'/'date' allows for people to have a date + time picker where the user selects the date first (Good for if you want them to be able to configure date but they normally only need to enter a time - IE: Faster data entry)

reOpenDefault: false/'date'/'time' allows for configuring what picker you want to open by default when the control is reopened. Same reason as previous option, used in conjunction will allow time picker to show first all the time, with the option of using the date picker. If `false` is specified then it will default to the behaviour that was previously implemented (See README.md changes for docs)