### PR TITLE
Don't focus on the picker when clicked elsewhere in the window to close it.

### DIFF
--- a/datetime-picker.js
+++ b/datetime-picker.js
@@ -401,10 +401,12 @@ angular.module('ui.bootstrap.datetimepicker', ['ui.bootstrap.dateparser', 'ui.bo
 
                 // if a on-close-fn has been defined, lets call it
                 // we only call this if closePressed is defined!
-                if (angular.isDefined(closePressed))
+                if (angular.isDefined(closePressed)) {
                     $scope.whenClosed({ args: { closePressed: closePressed, openDate: cache['openDate'] || null, closeDate: $scope.date } });
-
-                $element[0].focus();
+                }
+                else {
+                    $element[0].focus();
+                }
             };
 
             $scope.$on('$destroy', function () {


### PR DESCRIPTION
Only focus on the picker when it's clicked on it to close it. Not focus when clicked elsewhere to close it. 

E.g. The user clicks on the picker to open it, selects a date or time or both and then does not use the close/ done button or clicks again on the input to close it. Instead he clicks in the next input field to move on in his form. The picker now focuses again on the picker, so the user has to click twice instead of once to focus the next input field.

This pull request prevents it and only focuses after closing when clicked on done or again on the picker input.