### PR TITLE
Remove dependencies from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,6 @@
   "description": "AngularJs directive to use a date and/or time picker as a dropdown from an input",
   "license": "MIT",
   "main": "dist/datetime-picker.js",
-  "dependencies": {
-    "angular": "^1.4.0",
-    "angular-ui-bootstrap": "^1.2.0",
-    "grunt": "^0.4.5",
-    "grunt-angular-templates": "^0.5.9",
-    "grunt-contrib-concat": "^0.5.1",
-    "grunt-contrib-uglify": "^0.11.0"
-  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-angular-templates": "^0.5.7",


### PR DESCRIPTION
Client site libraries that are published on NPM usually don't specify any dependencies field so the user can decide for themselves on how to load the dependencies (though a CDN for example).

Other examples of client side libraries that have been publisher to NPM
and have no dependencies specified:
https://github.com/angular-ui/bootstrap/blob/d9dd5803aef1411e13a70bbde3f8074abd3373e5/package.json#L6
https://github.com/rubenv/angular-gettext/blob/31a175c4d85e793a694bc5dfeb956fccabd05d76/package.json#L25
https://github.com/angular-ui/ui-router/blob/696148f199002adbdfcf864894acf96894e06ed6/package.json#L56

The definitely don't have their devDependencies in their normal dependencies as this library does with grunt.

Most people just `npm install` this library for the `dist/datetime-picker.js`. But doing so right now also pulls in grunt and its many many dependencies.