### PR TITLE
Exports angular module name

### DIFF
--- a/dist/datetime-picker.js
+++ b/dist/datetime-picker.js
@@ -657,3 +657,5 @@ angular.module('ui.bootstrap.datetimepicker').run(['$templateCache', function($t
   );
 
 }]);
+
+module.exports = 'ui.bootstrap.datetimepicker'


### PR DESCRIPTION
For easy require: 
```javascript
var app = angular.module('appModule', [
  require('bootstrap-ui-datetime-picker') //<----
  require('angular-route'     ),
  require('angular-animate'   ),
  require('angularjs-toaster' ),
  require('angular-datatables')
]);
```