### PR TITLE
Fixes #230

### DIFF
--- a/datetime-picker.js
+++ b/datetime-picker.js
@@ -765,6 +765,7 @@ angular.module('ui.bootstrap.datetimepicker', ['ui.bootstrap.dateparser', 'ui.bo
     .directive('datePickerWrap', function () {
         return {
             restrict: 'EA',
+            priority: 2,
             replace: true,
             transclude: true,
             templateUrl: 'template/date-picker.html'
@@ -774,6 +775,7 @@ angular.module('ui.bootstrap.datetimepicker', ['ui.bootstrap.dateparser', 'ui.bo
     .directive('timePickerWrap', function () {
         return {
             restrict: 'EA',
+            priority: 2,
             replace: true,
             transclude: true,
             templateUrl: 'template/time-picker.html'


### PR DESCRIPTION
The current code applies the directives ``date-picker-wrap`` and ``time-picker-wrap`` alongside ``ng-model``. ``ng-model`` runs with a priority of 1 and the default priority of custom directives is 0. So the following is the current flow of code.

1. ng-model pre-link function runs.
2. Custom wrap directive gets compiled, it's inner ng-if gets picked up and evaluated resulting in it being removed from DOM and replaced with a comment node.
3. ng-model post-link function runs but it gets the commented node passed in as the template to operate upon, leading to the infinite recursion error.

Why is the infinite recursion error occuring? jQuery 3.4.x made changes to the way it handles blur/focus events. This new code gets executed everytime an event handler is registered on the blur/focus events which is being done internally by ``ng-model``.  This leads to the infinite recursion error if event listener is getting bound to a commented node.

The issue can be fixed by changing the priority of the custom wrap directives so that their code executes before ``ng-model``. The element will already be removed from DOM and ngModel will not get evaluated on an "invalid" node.